### PR TITLE
adjusts the `btcUtxoDustLimit` default value from 10000 to 1000 for BTC mainnet

### DIFF
--- a/packages/btc/src/preset/config.ts
+++ b/packages/btc/src/preset/config.ts
@@ -13,7 +13,7 @@ const defaultConfigs: Record<'testnet' | 'mainnet', RgbppBtcConfig> = {
   },
   mainnet: {
     feeRate: 20,
-    btcUtxoDustLimit: 10000,
+    btcUtxoDustLimit: 1000,
     rgbppUtxoDustLimit: 546,
     network: bitcoin.networks.bitcoin,
     networkType: NetworkType.MAINNET,

--- a/packages/btc/src/preset/types.ts
+++ b/packages/btc/src/preset/types.ts
@@ -15,7 +15,7 @@ export interface RgbppBtcConfig {
   /**
    * The minimum satoshi amount that can be declared in a BTC_UTXO.
    * BTC_UTXOs with satoshi below this constant are considered dust and will not be collected/created.
-   * Officially, this constant should be 1,0000, but currently we are using 1,000 for testing purposes.
+   * Default is 1000 satoshis for both mainnet and testnet.
    */
   btcUtxoDustLimit: number;
   /**

--- a/packages/rgbpp/src/rgbpp/types/xudt.ts
+++ b/packages/rgbpp/src/rgbpp/types/xudt.ts
@@ -37,6 +37,9 @@ export interface RgbppTransferBtcParams {
   feeRate?: number;
   // The Bitcoin Testnet type including Testnet3 and Signet, default value is Testnet3
   testnetType?: BTCTestnetType;
+
+  // The minimum satoshi amount that can be declared in a BTC_UTXO.
+  minUtxoSatoshi?: number;
 }
 
 export interface RgbppTransferTxParams {
@@ -94,6 +97,8 @@ export interface RgbppTransferAllTxsParams {
     // The BTC Testnet to use, supports "Testnet3" and "Signet", default value is "Testnet3",
     // the param helps find the targeting version of rgbpp-lock script on CKB Testnet
     testnetType?: BTCTestnetType;
+    // The minimum satoshi amount that can be declared in a BTC_UTXO.
+    minUtxoSatoshi?: number;
   };
   // True is for BTC and CKB Mainnet, false is for BTC Testnet3/Signet and CKB Testnet
   isMainnet: boolean;

--- a/packages/rgbpp/src/rgbpp/xudt/btc-transfer-all.ts
+++ b/packages/rgbpp/src/rgbpp/xudt/btc-transfer-all.ts
@@ -194,6 +194,7 @@ export async function buildRgbppTransferAllTxs(params: RgbppTransferAllTxsParams
       feeRate: params.btc.feeRate,
       excludeUtxos: usedBtcUtxos,
       source: btcSource,
+      minUtxoSatoshi: params.btc.minUtxoSatoshi,
     });
 
     // Exclude used BTC UTXOs in the next BTC_TX

--- a/packages/rgbpp/src/rgbpp/xudt/btc-transfer.ts
+++ b/packages/rgbpp/src/rgbpp/xudt/btc-transfer.ts
@@ -53,6 +53,7 @@ export const buildRgbppTransferTx = async ({
     fromPubkey: btc.fromPubkey,
     source: btc.dataSource,
     feeRate: btc.feeRate,
+    minUtxoSatoshi: btc.minUtxoSatoshi,
   });
 
   return {


### PR DESCRIPTION
With the recent reduction of `PAYMASTER_BTC_CONTAINER_FEE_SATS` in btc-assets-api paymaster (now below 10000), certain wrapper methods such as `buildRgbppTransferAllTxs` and `buildRgbppTransferTx` that don't support the `minUtxoSatoshi` parameter would fail with `ErrorCodes.DUST_OUTPUT` during transaction construction.

Lowering the `btcUtxoDustLimit` to 1000 provides a more reasonable default.